### PR TITLE
fix yarn run command on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ or [macOS Terminal](https://support.apple.com/guide/terminal/welcome/mac))
   - `APS_CLIENT_ID` - your APS application client ID
   - `APS_CLIENT_SECRET` - your APS application client secret
   - `APS_BUCKET` (optional) - name of APS bucket to store your designs in
-- Run the server: `yarn install` or `npm start`
+- Run the server: `yarn start` or `npm start`
 
 > When using [Visual Studio Code](https://code.visualstudio.com),
 you can specify the env. variables listed above in a _.env_ file in this


### PR DESCRIPTION
Fixes a  typo present in the readme, changing the cmd from `yarn install` to `yarn start`.