### PR TITLE
add dotenv dep for easier .env loading

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,3 +1,6 @@
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
+
 let { APS_CLIENT_ID, APS_CLIENT_SECRET, APS_BUCKET, PORT } = process.env;
 if (!APS_CLIENT_ID || !APS_CLIENT_SECRET) {
     console.warn('Missing some of the environment variables.');

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "license": "MIT",
   "dependencies": {
+    "dotenv": "^16.3.1",
     "express": "^4.17.1",
     "express-formidable": "^1.2.0",
     "forge-apis": "^0.9.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -201,6 +201,11 @@ destroy@1.2.0:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
+dotenv@^16.3.1:
+  version "16.3.1"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.3.1.tgz#369034de7d7e5b120972693352a3bf112172cc3e"
+  integrity sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==
+
 ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"


### PR DESCRIPTION
Add the `dotenv` dependency to facilitate loading the values in the `.env` file directly into the `config.js` file. I followed the exact same pattern used in the `aps-iot-extensions-demo` application.